### PR TITLE
Fix SampleDecoder shards order

### DIFF
--- a/src/ReedSolomon.NET.Sample/SampleDecoder.cs
+++ b/src/ReedSolomon.NET.Sample/SampleDecoder.cs
@@ -20,6 +20,7 @@ public static class SampleDecoder
         // var shardsList = Directory.GetFiles(@"path_to_directory/", "data.bin.*");
         // Exclude the file that name end by .bin
         var shardsList = Directory.GetFiles(@"path_to_directory/", "data.extension.*")
+            .OrderBy(file => int.Parse(file.Split('.').Last()))
             .Where(file => !file.EndsWith(".extension")).ToList();
         var shardsCount = shardsList.Count;
         var shardPresent = new bool[TotalShards];


### PR DESCRIPTION
Fixes #1 

Issue appearing due to wrong shards order. Official MS documentation marks that [Directory.GetFiles Method](https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netstandard-2.1) do not guarantee the order of the returned file names. Explicitly order shards by adding _OrderBy_ LINQ instruction fix the problem in SampleDecoder. 